### PR TITLE
bug: Meetup Pro API has different field names

### DIFF
--- a/get_events.R
+++ b/get_events.R
@@ -34,11 +34,24 @@ groups <- groups |>
 possibly_get_events <- possibly(meetupr:::get_group_events,
                                 otherwise = NA)
 
+# We want this format for events:
+# > readr::read_rds('/tmp/events.rds') |> names()
+#  [1] "group.id"      "urlname"       "id"            "title"
+#  [5] "link"          "status"        "time"          "duration"
+#  [9] "going"         "waiting"       "description"   "venue_id"
+# [13] "venue_lat"     "venue_lon"     "venue_name"    "venue_address"
+# [17] "venue_city"    "venue_state"   "venue_zip"     "venue_country"
+# [21] "event_status"
+
 events <- groups |>
   rowwise() |>
   mutate(data = map(urlname, possibly_get_events)) |>
-  unnest(data,names_sep='.') |>
-  mutate(event_status = data.status)
+  unnest(data) |>
+  mutate(event_status = status,
+         time = date_time,
+         going = rsvps_count,
+         link = event_url,
+         venue_name = venues_name)
 
 pins::pin_write(board, events,
                 name = "events")

--- a/meetup_report.Rmd
+++ b/meetup_report.Rmd
@@ -189,7 +189,7 @@ events %>%
   transmute(Event = glue('[{title}]({link})'), 
             time = as.Date(time), Location,
             Group = glue('[{urlname}](https://meetup.com/{urlname})'),
-            going, waiting, is_online_event,
+            going, is_online_event,
             #result = glue('[Discourse]({result})')
   ) -> up_events
 ```
@@ -201,7 +201,7 @@ up_events %>%
   fmt_markdown(columns = c('Event','Group')) %>%
   cols_label(
     time = "Date",
-    going = "Going", waiting = "Waitlist",
+    going = "Going",
     is_online_event = 'Virtual?',
     #result = 'Discourse'
   )
@@ -219,13 +219,13 @@ events %>%
   arrange(desc(time)) %>%
   transmute(Event = glue('[{title}]({link})'),
             time = as.Date(time), Location,
-            going, waiting, is_online_event,
+            going, is_online_event,
             Group = glue('[{urlname}](https://meetup.com/{urlname})')) %>%
   gt() %>%
   fmt_markdown(columns = c('Group','Event')) %>%
   cols_label(
     time = "Date",
-    going = "Went", waiting = "Waitlist",
+    going = "Went",
     is_online_event = 'Virtual?'
   )
 ```

--- a/update_discourse.R
+++ b/update_discourse.R
@@ -162,7 +162,7 @@ events |>
   distinct(id, .keep_all = T) |>
   filter(time > Sys.Date() - lubridate::days(1)) |>
   filter(time <= Sys.Date() + 90) |>
-  filter(status == 'published') |>
+  filter(status == 'ACTIVE') |>
   push_to_discourse() |>
   arrange(time) %>%
   transmute(Event = title,
@@ -170,5 +170,4 @@ events |>
             Location,
             Group = urlname,
             going,
-            waiting,
             result)


### PR DESCRIPTION
We don't use waiting list, so remove it

NOTE: Does not filter out Network events, so currently if we have an network event, we'd end up with one Forum post per group in our network.

Replaces https://github.com/ansible-community/stats-container-meetups/pull/5